### PR TITLE
Additional stone rules

### DIFF
--- a/apps/go_stop_web/lib/go_stop_web/resolvers/stone.ex
+++ b/apps/go_stop_web/lib/go_stop_web/resolvers/stone.ex
@@ -1,11 +1,29 @@
 defmodule GoStopWeb.Resolvers.Stone do
-  alias GoStop.Stone
+  alias Ecto.Multi
 
-  def add_stone(_parent, data, %{context: %{current_user: _}}) do
-    case GoStop.Stone.create(data) do
-      {:ok, _} = stone -> stone
-      {:error, changeset} -> {:error, "Failed: #{parse_errors(changeset)}"}
-    end
+  alias GoStop.{Repo, Stone}
+
+  def add_stone(_parent,
+    %{game_id: game_id} = data, %{context: %{current_user: current_user}}) do
+      result =
+        Repo.transaction(fn ->
+          case GoStop.Stone.create(data) do
+            {:ok, stone} ->
+              if player_turn?(game_id, current_user) do
+                stone
+              else
+                Repo.rollback(:wrong_turn)
+              end
+            {:error, changeset} -> Repo.rollback("Failed: #{parse_errors(changeset)}")
+          end
+        end)
+
+      case result do
+        {:ok, stone} = stone -> stone
+        {:error, :wrong_turn} ->
+          {:error, "Failed: wrong player turn"}
+        err -> err
+      end
   end
 
   def add_stone(_, _, _) do
@@ -16,5 +34,14 @@ defmodule GoStopWeb.Resolvers.Stone do
     Enum.map(changeset.errors, fn {k, {v, _}} ->
       "#{k} #{v}"
     end)
+  end
+
+  defp player_turn?(game_id, current_user) do
+    case GoStop.Game.get(game_id, preload: [:players]) do
+      nil -> false
+      game ->
+        player = Enum.find(game.players, fn p -> p.user_id == current_user.id end)
+        player && player.id == game.player_turn_id
+    end
   end
 end


### PR DESCRIPTION
- Disallow adding Stones out of turn
- Disallow adding Stones to Games without being a Player in that Game
- Update `player_turn_id` upon adding Stone