### PR TITLE
Auto-assign colors

### DIFF
--- a/apps/go_stop/lib/go_stop/models/player.ex
+++ b/apps/go_stop/lib/go_stop/models/player.ex
@@ -6,6 +6,7 @@ defmodule GoStop.Player do
 
   schema "players" do
     field(:status, :string)
+    field(:color, :string)
     embeds_one(:stats, Player.Stats)
     belongs_to(:user, User)
     belongs_to(:game, Game)
@@ -13,8 +14,9 @@ defmodule GoStop.Player do
     timestamps()
   end
 
-  @fields [:user_id, :game_id, :status]
+  @fields [:user_id, :game_id, :status, :color]
   @accepted_statuses ~w(user-pending active)
+  @accepted_colors ~w(black white)
 
   def create(attrs) do
     %Player{}
@@ -37,8 +39,10 @@ defmodule GoStop.Player do
     |> cast(params, @fields)
     |> validate_required(@fields)
     |> validate_inclusion(:status, @accepted_statuses)
+    |> validate_inclusion(:color, @accepted_colors)
     |> assoc_constraint(:user)
     |> assoc_constraint(:game)
+    |> unique_constraint(:color, name: :players_game_id_color_index)
     |> cast_embed(:stats, with: &Player.Stats.changeset/2)
   end
 end

--- a/apps/go_stop/lib/go_stop/models/stone.ex
+++ b/apps/go_stop/lib/go_stop/models/stone.ex
@@ -7,7 +7,7 @@ defmodule GoStop.Stone do
   schema "stones" do
     field :x, :integer
     field :y, :integer
-    field :color, :integer
+    field :color, :string
     belongs_to :game, Game
 
     timestamps()
@@ -15,9 +15,7 @@ defmodule GoStop.Stone do
 
   @required_fields [:x, :y, :color, :game_id]
 
-  # White: 0
-  # Black: 1
-  @accepted_colors [0, 1]
+  @accepted_colors ~w(black white)
 
   @accepted_coords 0..18
 

--- a/apps/go_stop/priv/repo/migrations/20180121080858_add_players_table.exs
+++ b/apps/go_stop/priv/repo/migrations/20180121080858_add_players_table.exs
@@ -6,6 +6,7 @@ defmodule GoStop.Repo.Migrations.AddPlayersTable do
       add :user_id, references(:users)
       add :game_id, references(:games)
       add :status, :string, null: false
+      add :color, :string, null: false
       add :stats, :map
 
       timestamps()
@@ -13,5 +14,6 @@ defmodule GoStop.Repo.Migrations.AddPlayersTable do
 
     create index(:players, :user_id)
     create index(:players, :game_id)
+    create unique_index(:players, [:game_id, :color])
   end
 end

--- a/apps/go_stop/priv/repo/migrations/20180323042134_add_stones_table.exs
+++ b/apps/go_stop/priv/repo/migrations/20180323042134_add_stones_table.exs
@@ -5,7 +5,7 @@ defmodule GoStop.Repo.Migrations.AddStonesTable do
     create table(:stones) do
       add :x, :integer, null: false
       add :y, :integer, null: false
-      add :color, :integer, null: false
+      add :color, :string, null: false
       add :game_id, references(:games), null: false
 
       timestamps()

--- a/apps/go_stop/priv/repo/seeds.exs
+++ b/apps/go_stop/priv/repo/seeds.exs
@@ -14,7 +14,8 @@ defmodule GoStop.Seeds do
     1..5
     |> Enum.map(fn _ ->
       game = create_game()
-      1..2 |> Enum.map(fn _ -> create_player(%{game_id: game.id}) end)
+      create_player(%{game_id: game.id, color: "black"})
+      create_player(%{game_id: game.id, color: "white"})
     end)
   end
 
@@ -40,13 +41,14 @@ defmodule GoStop.Seeds do
     game
   end
 
-  def create_player(%{game_id: game_id}) do
+  def create_player(%{game_id: game_id, color: color}) do
     [status] = Enum.take_random(~w(user-pending active), 1)
     {:ok, player} =
       %{
         status: status,
         user_id: create_user().id,
-        game_id: game_id
+        game_id: game_id,
+        color: color
       }
       |> GoStop.Player.create
 

--- a/apps/go_stop/test/models/stone_test.exs
+++ b/apps/go_stop/test/models/stone_test.exs
@@ -6,7 +6,7 @@ defmodule GoStop.StoneTest do
   @params %{
     x: 0,
     y: 0,
-    color: 1, # Black
+    color: "black",
     game_id: 1
   }
 
@@ -20,7 +20,7 @@ defmodule GoStop.StoneTest do
     test "is invalid with improper color" do
       changeset = Stone.changeset(%Stone{}, %{@params | color: 4})
       refute is_valid(changeset)
-      assert changeset.errors == [color: {"is invalid", [validation: :inclusion]}]
+      assert [color: {"is invalid", _}] = changeset.errors
     end
 
     test "is invalid with a wrong coordinate" do

--- a/apps/go_stop/test/support/factory.ex
+++ b/apps/go_stop/test/support/factory.ex
@@ -20,10 +20,12 @@ defmodule GoStop.Factory do
 
   def player_factory do
     [status] = ~w(user-pending active) |> Enum.take_random(1)
+    [color] = ~w(black white) |> Enum.take_random(1)
     %Player{
       status: status,
       user: build(:user),
-      game: build(:game)
+      game: build(:game),
+      color: color
     }
   end
 end

--- a/apps/go_stop_web/lib/go_stop_web/resolvers/game.ex
+++ b/apps/go_stop_web/lib/go_stop_web/resolvers/game.ex
@@ -17,10 +17,20 @@ defmodule GoStopWeb.Resolvers.Game do
           Game.create(%{status: "pending"})
         end)
         |> Multi.run(:player_1, fn %{game: game} ->
-          Player.create(%{status: "active", user_id: current_user.id, game_id: game.id})
+          Player.create(%{
+            status: "active",
+            user_id: current_user.id,
+            game_id: game.id,
+            color: "black"
+          })
         end)
         |> Multi.run(:player_2, fn %{game: game} ->
-          Player.create(%{status: "user-pending", user_id: opponent_id, game_id: game.id})
+          Player.create(%{
+            status: "user-pending",
+            user_id: opponent_id,
+            game_id: game.id,
+            color: "white"
+          })
         end)
         |> Multi.run(:updated_game, fn %{game: game, player_1: player_1} ->
           game = Repo.preload(game, preloads())

--- a/apps/go_stop_web/lib/go_stop_web/resolvers/stone.ex
+++ b/apps/go_stop_web/lib/go_stop_web/resolvers/stone.ex
@@ -5,34 +5,26 @@ defmodule GoStopWeb.Resolvers.Stone do
 
   def add_stone(_parent,
     %{game_id: game_id} = data, %{context: %{current_user: current_user}}) do
-      multi =
-        Multi.new
-        |> Multi.run(:stone, fn _ ->
-          case GoStop.Stone.create(data) do
-            {:ok, stone} ->
-              # TODO: refactor this section to be extensible for game rules
-              if player_turn?(game_id, current_user) do
-                {:ok, stone |> Repo.preload(:game)}
-              else
-                changeset =
-                  stone
-                  |> Stone.changeset(%{})
-                  |> Changeset.add_error(:player, "must wait a turn")
-                {:error, changeset}
-              end
-            err -> err
-          end
-        end)
-        |> Multi.run(:game, fn %{stone: stone} ->
-          game = stone.game |> Repo.preload(:players)
-          {game, new_player} = get_new_player(game, current_user)
-          Game.update(game, %{player_turn_id: new_player.id})
-        end)
+      game = get_game(game_id)
 
-      case Repo.transaction(multi) do
-        {:ok, %{stone: stone}} -> {:ok, stone}
-        {:error, _name, changeset, _} ->
-          {:error, "Failed: #{parse_errors(changeset)}"}
+      changeset = Stone.changeset(%Stone{}, %{})
+
+      if game do
+        player = get_player(game, current_user)
+
+        if player do
+          player = player |> Repo.preload(:game)
+
+          if player_turn?(player) do
+            create_stone(data, player)
+          else
+            {:error, "Failed: player must wait a turn"}
+          end
+        else
+          {:error, "Failed: player does not exist"}
+        end
+      else
+        {:error, "Failed: game does not exist"}
       end
   end
 
@@ -46,17 +38,42 @@ defmodule GoStopWeb.Resolvers.Stone do
     end)
   end
 
-  defp player_turn?(game_id, current_user) do
-    case Game.get(game_id, preload: [:players]) do
-      nil -> false
-      game ->
-        player = Enum.find(game.players, fn p -> p.user_id == current_user.id end)
-        player && player.id == game.player_turn_id
-    end
+  defp get_game(game_id) do
+    Game.get(game_id, preload: [:players])
   end
 
-  defp get_new_player(game, current_user) do
-    player = Enum.find(game.players, fn p -> p.user_id != current_user.id end)
+  defp get_player(game, current_user) do
+    Enum.find(game.players, fn p -> p.user_id == current_user.id end)
+  end
+
+  defp player_turn?(player) do
+    player && player.id == player.game.player_turn_id
+  end
+
+  defp get_new_player(game, player) do
+    player = Enum.find(game.players, fn p -> p.id != player.id end)
     {game, player}
+  end
+
+
+  defp create_stone(data, player) do
+    multi =
+      Multi.new
+      |> Multi.run(:stone, fn _ ->
+        params = Map.put(data, :color, player.color)
+        Stone.create(params)
+      end)
+      |> Multi.run(:game, fn %{stone: stone} ->
+        stone = stone |> Repo.preload(:game)
+        game = stone.game |> Repo.preload(:players)
+        {game, new_player} = get_new_player(game, player)
+        Game.update(game, %{player_turn_id: new_player.id})
+      end)
+
+    case Repo.transaction(multi) do
+      {:ok, %{stone: stone}} -> {:ok, stone}
+      {:error, _name, changeset, _} ->
+        {:error, "Failed: #{parse_errors(changeset)}"}
+    end
   end
 end

--- a/apps/go_stop_web/lib/go_stop_web/schema.ex
+++ b/apps/go_stop_web/lib/go_stop_web/schema.ex
@@ -74,7 +74,6 @@ defmodule GoStopWeb.Schema do
     field :add_stone, :stone do
       arg :x, non_null(:integer)
       arg :y, non_null(:integer)
-      arg :color, non_null(:integer)
       arg :game_id, non_null(:id)
 
       resolve &Resolvers.Stone.add_stone/3

--- a/apps/go_stop_web/test/go_stop_web/schema/schema_test.exs
+++ b/apps/go_stop_web/test/go_stop_web/schema/schema_test.exs
@@ -328,8 +328,8 @@ defmodule GoStopWeb.SchemaTest do
 
   describe "addStone" do
     setup do
-      player = insert(:player)
-      insert(:player, %{game: player.game})
+      player = insert(:player, %{color: "white"})
+      insert(:player, %{game: player.game, color: "black"})
 
       {:ok, token, _} = encode_and_sign(player.user, %{}, token_type: :access)
 
@@ -345,7 +345,7 @@ defmodule GoStopWeb.SchemaTest do
 
         query = """
         mutation AddStone {
-          addStone(gameId: #{game.id}, x: 0, y: 0, color: 0) {
+          addStone(gameId: #{game.id}, x: 0, y: 0) {
             color
           }
         }
@@ -356,7 +356,7 @@ defmodule GoStopWeb.SchemaTest do
           |> post("/api", %{query: query})
           |> json_response(200)
 
-        assert res == %{"data" => %{"addStone" => %{"color" => 0}}}
+        assert res == %{"data" => %{"addStone" => %{"color" => "white"}}}
         refute Game.get(game.id).player_turn_id == player.id
     end
 
@@ -364,7 +364,7 @@ defmodule GoStopWeb.SchemaTest do
       %{conn: conn, player: player, token: token} do
         query = """
         mutation AddStone {
-          addStone(game_id: #{player.game.id}, x: 0, y: 0, color: 0) {
+          addStone(game_id: #{player.game.id}, x: 0, y: 0) {
             id
           }
         }
@@ -389,7 +389,7 @@ defmodule GoStopWeb.SchemaTest do
 
         query = """
         mutation AddStone {
-          addStone(game_id: #{game.id}1, x: 0, y: 0, color: 0) {
+          addStone(game_id: #{game.id}1, x: 0, y: 0) {
             id
           }
         }


### PR DESCRIPTION
We now auto-assign colors to Players on Game creation. When a Player adds a stone, it will now be created with the color that the Player has. 

Players now have a `color` column, and there is a `unique_constraint` between `game_id` and `color`, so that both Players will not have the same color.

The `color` column on Players and Stones is a string with limited values "black" or "white"