### PR TITLE
Give Players stats on captured stones

### DIFF
--- a/apps/go_stop/lib/go_stop/models/player.ex
+++ b/apps/go_stop/lib/go_stop/models/player.ex
@@ -5,12 +5,12 @@ defmodule GoStop.Player do
   alias GoStop.{Repo, User, Game, Player}
 
   schema "players" do
-    field(:status, :string)
-    field(:color, :string)
-    field(:has_passed, :boolean, default: false)
-    embeds_one(:stats, Player.Stats)
-    belongs_to(:user, User)
-    belongs_to(:game, Game)
+    field :status, :string
+    field :color, :string
+    field :has_passed, :boolean, default: false
+    embeds_one :stats, Player.Stats
+    belongs_to :user, User
+    belongs_to :game, Game
 
     timestamps()
   end
@@ -36,6 +36,7 @@ defmodule GoStop.Player do
   def create(attrs) do
     %Player{}
     |> changeset(attrs)
+    |> put_change(:stats, %{})
     |> Repo.insert()
   end
 
@@ -69,7 +70,14 @@ defmodule GoStop.Player do
     player.id == player.game.player_turn_id
   end
 
-  def changeset(struct, params) do
+  def capture_stone(player) do
+    player
+    |> changeset
+    |> put_embed(:stats, Player.Stats.capture_stone(player.stats))
+    |> Repo.update
+  end
+
+  def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @fields)
     |> validate_required(@fields)
@@ -78,6 +86,6 @@ defmodule GoStop.Player do
     |> assoc_constraint(:user)
     |> assoc_constraint(:game)
     |> unique_constraint(:color, name: :players_game_id_color_index)
-    |> cast_embed(:stats, with: &Player.Stats.changeset/2)
+    |> cast_embed(:stats)
   end
 end

--- a/apps/go_stop/lib/go_stop/models/stats.ex
+++ b/apps/go_stop/lib/go_stop/models/stats.ex
@@ -1,2 +1,26 @@
 defmodule GoStop.Player.Stats do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias GoStop.{Repo, Player}
+
+  @accepted_fields [:captured_stones]
+
+  @primary_key false
+  embedded_schema do
+    field :captured_stones, :integer, default: 0
+  end
+
+  def capture_stone(nil) do
+    capture_stone(%Player.Stats{})
+  end
+  def capture_stone(stats) do
+    stats
+    |> changeset(%{captured_stones: stats.captured_stones + 1})
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @accepted_fields)
+  end
 end

--- a/apps/go_stop/test/models/player_stats_test.exs
+++ b/apps/go_stop/test/models/player_stats_test.exs
@@ -1,0 +1,12 @@
+defmodule GoStop.PlayerStatsTest do
+  use GoStop.DataCase, async: true
+
+  alias GoStop.Player
+
+  test "it can increment captured_stones" do
+    player = insert(:player)
+
+    {:ok, player} = Player.capture_stone(player)
+    assert player.stats.captured_stones == 1
+  end
+end

--- a/apps/go_stop/test/models/player_test.exs
+++ b/apps/go_stop/test/models/player_test.exs
@@ -65,6 +65,18 @@ defmodule PlayerTest do
         Player.create(%{@params | game_id: player.game_id, color: player.color})
       assert [color: {"has already been taken", _}] = changeset.errors
     end
+
+    test "creates initial Player stats" do
+      game = insert(:game)
+      user = insert(:user)
+      {:ok, %{stats: stats}} =
+        :player
+        |> build(%{game_id: game.id, user_id: user.id})
+        |> Map.from_struct
+        |> Player.create
+
+      assert stats == %Player.Stats{captured_stones: 0}
+    end
   end
 
   describe "#get" do


### PR DESCRIPTION
[closes #32]

When a new Player is created, that Player will have valid `stats`. So far,
this includes a `captured_stones` field, an integer that starts at 0.

Also added a `Player.capture_stone` action and `Player.Stats.capture_stone`
helper that will increment `captured_stones` by 1. This will later be
extended to allow adding multiple stones at once.