### PR TITLE
Add currentUser query

### DIFF
--- a/apps/go_stop_web/lib/go_stop_web/resolvers/authorization.ex
+++ b/apps/go_stop_web/lib/go_stop_web/resolvers/authorization.ex
@@ -11,7 +11,8 @@ defmodule GoStopWeb.Resolvers.Authorization do
   defp check_password(password, user) do
     if Comeonin.Bcrypt.checkpw(password, user.encrypted_password) do
       {:ok, token, _claims} = GoStopWeb.Guardian.encode_and_sign(user)
-      {:ok, %{token: token}}
+      user = user |> Map.from_struct() |> Map.put(:token, token)
+      {:ok, user}
     else
       {:error, "Failed: invalid username/password combination"}
     end

--- a/apps/go_stop_web/lib/go_stop_web/resolvers/user.ex
+++ b/apps/go_stop_web/lib/go_stop_web/resolvers/user.ex
@@ -20,6 +20,13 @@ defmodule GoStopWeb.Resolvers.User do
     {:ok, GoStop.User.get_by(data, preload: preloads())}
   end
 
+  def get_current_user(_parent, _data, %{context: %{current_user: current_user}}) do
+    {:ok, current_user}
+  end
+  def get_current_user(_parent, _data, _resolution) do
+    authentication_error()
+  end
+
   defp preloads do
     :games
   end

--- a/apps/go_stop_web/lib/go_stop_web/schema.ex
+++ b/apps/go_stop_web/lib/go_stop_web/schema.ex
@@ -20,6 +20,11 @@ defmodule GoStopWeb.Schema do
       resolve &Resolvers.User.get_user/3
     end
 
+    @desc "Get current User information"
+    field :current_user, :user do
+      resolve &Resolvers.User.get_current_user/3
+    end
+
     @desc "Get all Games"
     field :games, list_of(:game) do
       resolve &Resolvers.Game.list_games/3


### PR DESCRIPTION
When a client makes a query for `getUser` with a `token` in the header, it gets a `User` back.

```
query {
  currentUser {
    username
  }
}
```